### PR TITLE
ci: migrate to Blacksmith runners

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Build
 
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: 8
           distribution: adopt
           
-      - uses: actions/cache@v6
+      - uses: actions/cache@v6.0.0
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: 8
           distribution: adopt
           
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: 8
           distribution: adopt
           
-      - uses: actions/cache@v3.2.3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
Migrates all GitHub-hosted runners in this repo to [Blacksmith](https://blacksmith.sh).

`runs-on: ubuntu-latest` → `blacksmith-2vcpu-ubuntu-2404` (2 vCPU Blacksmith instance), matching the org convention already used in `MentionMe` and `app.mention-me.com`.

Files changed: .github/workflows/android.yml 

Part of the org-wide move off GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzLWqXuUFndaLsv3MKgRqJ