### PR TITLE
chore: CODEOWNERS team ownership sweep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mention-me/engineering


### PR DESCRIPTION
Standardise code ownership across the org.

Adds/normalises `.github/CODEOWNERS` so every repo has a team-based `*` default owner and legacy/ghost team tokens are retired (Stage 3 of the teams/permissions rollout).

Auto-generated sweep.